### PR TITLE
feat: add implementation for timestamps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 120
 
 [tool.poetry]
 name = "django-backblaze-b2"
-version = "2.1.0"
+version = "2.1.1"
 description = "A Django app to use backblaze b2 as storage."
 authors = ["Etienne H <django_backblaze_b2@internet-e-mail.com>"]
 maintainers = ["Etienne H <django_backblaze_b2@internet-e-mail.com>"]


### PR DESCRIPTION
This adds implementations for `get_created_time`
and `get_modified_time` based on the default
django `FilesystemStorage`